### PR TITLE
Transmitter Rewritten

### DIFF
--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -105,16 +105,7 @@ def adat_decode(signal):
 
     while len(signal) >= 255:
         current_frame = []
-        for _ in range(10):
-            assert signal.pop(0) == 0
 
-        assert signal.pop(0) == 1
-
-        user_data = decode_nibble(signal)
-        signal = signal[4:]
-        print("user data: " + hex(user_data))
-
-        current_frame.append(user_data)
         for channel in range(8):
             print("channel " + str(channel))
             sample = 0
@@ -126,8 +117,21 @@ def adat_decode(signal):
                 sample += nibble << (4 * (5 - nibble_no))
             print("got sample " + hex(sample))
             current_frame.append(sample)
-        result.append(current_frame)
+
         assert signal.pop(0) == 1
+
+        for _ in range(10):
+            assert signal.pop(0) == 0
+
+        assert signal.pop(0) == 1
+
+        user_data = decode_nibble(signal)
+        signal = signal[4:]
+        print("user data: " + hex(user_data))
+
+        current_frame.append(user_data)
+
+        result.append(current_frame)
 
     return result
 

--- a/tests/transmitter-bench.py
+++ b/tests/transmitter-bench.py
@@ -13,7 +13,7 @@ from adat.nrzidecoder import NRZIDecoder
 from testdata import *
 
 def test_with_samplerate(samplerate: int=48000):
-    clk_freq = 100e6
+    clk_freq = 50e6
     dut = ADATTransmitter()
     adat_freq = NRZIDecoder.adat_freq(samplerate)
     clockratio = clk_freq / adat_freq
@@ -38,6 +38,8 @@ def test_with_samplerate(samplerate: int=48000):
         if last:
             yield dut.last_in.eq(0)
 
+
+
     def wait(n_cycles: int):
         for _ in range(int(clockratio) * n_cycles):
             yield Tick("sync")
@@ -50,7 +52,7 @@ def test_with_samplerate(samplerate: int=48000):
             yield from write(i, i, drop_valid=True)
         for i in range(4):
             yield from write(4 + i, 0xc + i, i == 3, drop_valid=True)
-        yield from wait(300)
+        yield from wait(15)
         yield dut.user_data_in.eq(0xa)
         yield Tick("sync")
         for i in range(8):
@@ -70,13 +72,13 @@ def test_with_samplerate(samplerate: int=48000):
         yield dut.user_data_in.eq(0xe)
         yield Tick("sync")
         for i in range(8):
-            yield from write(i, (i + 1) << 20, i == 7)
+            yield from write(i, (i + 1) << 20, i == 7, drop_valid=True)
         yield from wait(900)
 
     def adat_process():
         nrzi = []
         i = 0
-        while i < 1600:
+        while i < 1650:
             yield Tick("adat")
             out = yield dut.adat_out
             nrzi.append(out)
@@ -84,16 +86,16 @@ def test_with_samplerate(samplerate: int=48000):
 
         # skip initial zeros
         nrzi = nrzi[nrzi.index(1):]
-        signal = decode_nrzi(nrzi)[1:]
+        signal = decode_nrzi(nrzi)
         decoded = adat_decode(signal)
         print(decoded)
-        user_bits = [frame[0] for frame in decoded]
-        assert user_bits == [0xf, 0xa, 0xb, 0xc, 0xd]
-        assert decoded[0][1:] == [0, 1, 2, 3, 0xc, 0xd, 0xe, 0xf]
-        assert decoded[1][1:] == [0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]
-        assert decoded[2][1:] == [0x100, 0x200, 0x300, 0x400, 0x500, 0x600, 0x700, 0x800]
-        assert decoded[3][1:] == [0x1000, 0x2000, 0x3000, 0x4000, 0x5000, 0x6000, 0x7000, 0x8000]
-        assert decoded[4][1:] == [0x10000, 0x20000, 0x30000, 0x40000, 0x50000, 0x60000, 0x70000, 0x80000]
+        user_bits = [frame[8] for frame in decoded]
+        assert user_bits == [0xf, 0xa, 0xb, 0xc, 0xd, 0xe]
+        assert decoded[0][:-1] == [0, 1, 2, 3, 0xc, 0xd, 0xe, 0xf]
+        assert decoded[1][:-1] == [0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]
+        assert decoded[2][:-1] == [0x100, 0x200, 0x300, 0x400, 0x500, 0x600, 0x700, 0x800]
+        assert decoded[3][:-1] == [0x1000, 0x2000, 0x3000, 0x4000, 0x5000, 0x6000, 0x7000, 0x8000]
+        assert decoded[4][:-1] == [0x10000, 0x20000, 0x30000, 0x40000, 0x50000, 0x60000, 0x70000, 0x80000]
 
     sim.add_sync_process(sync_process, domain="sync")
     sim.add_sync_process(adat_process, domain="adat")

--- a/tests/transmitter-smoke-test-48000.gtkw
+++ b/tests/transmitter-smoke-test-48000.gtkw
@@ -1,600 +1,109 @@
 [*]
-[*] GTKWave Analyzer v3.3.109 (w)1999-2020 BSI
-[*] Thu Aug 12 01:39:59 2021
+[*] GTKWave Analyzer v3.3.106 (w)1999-2020 BSI
+[*] Fri Jan  7 12:43:51 2022
 [*]
-[dumpfile] "transmitter-smoke-test-48000.vcd"
-[dumpfile_mtime] "Thu Aug 12 01:36:18 2021"
-[dumpfile_size] 395232
-[savefile] "transmitter-smoke-test-48000.gtkw"
+[dumpfile] "/home/rouven/Computer/Coden/Audio/adat-core/tests/transmitter-smoke-test-48000.vcd"
+[dumpfile_mtime] "Fri Jan  7 12:40:52 2022"
+[dumpfile_size] 310953
+[savefile] "/home/rouven/Computer/Coden/Audio/adat-core/tests/transmitter-smoke-test-48000.gtkw"
 [timestart] 0
-[size] 3828 2090
+[size] 1850 1011
 [pos] -1 -1
-*-23.969213 24032700 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
-[treeopen] top.
-[sst_width] 357
-[signals_width] 635
+*-26.000000 40900000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] bench.
+[treeopen] bench.top.
+[treeopen] bench.top.transmit_fifo.
+[sst_width] 227
+[signals_width] 350
 [sst_expanded] 1
-[sst_vpaned_height] 619
-@28
-top.clk
-@200
--Input Stream
+[sst_vpaned_height] 284
 @24
-top.addr_in[2:0]
-@22
-top.sample_in[23:0]
-top.user_bits[3:0]
+bench.top.adat_clk
 @28
-top.last_in
-top.ready_out
-top.valid_in
-@200
--Frame assembly
-@28
-[color] 7
-top.frame_complete
+bench.top.clk
 @22
-[color] 7
-top.channel0[23:0]
-[color] 7
-top.channel1[23:0]
-[color] 7
-top.channel2[23:0]
-[color] 7
-top.channel3[23:0]
-[color] 7
-top.channel4[23:0]
-[color] 7
-top.channel5[23:0]
-[color] 7
-top.channel6[23:0]
-[color] 7
-top.channel7[23:0]
-[color] 7
-top.user_bits[3:0]
-[color] 7
-top.assembled_frame[255:0]
-@200
--Transmit FIFO w/CDC
+bench.top.sample_in[23:0]
 @28
-[color] 3
-top.w_rdy
-[color] 3
-top.w_en
+bench.top.user_data_in[3:0]
+bench.top.valid_in
+bench.top.last_in
+bench.top.ready_out
+[color] 2
+bench.top.underflow_out
+[color] 1
+bench.top.adat_out
+@24
+bench.top.fifo_level_out[9:0]
+@28
+bench.top.transmit_fifo.w_en
 @22
-top.w_level[2:0]
-@c00023
-[color] 3
-top.w_data[255:0]
-@29
-[color] 3
-(0)top.w_data[255:0]
-[color] 3
-(1)top.w_data[255:0]
-[color] 3
-(2)top.w_data[255:0]
-[color] 3
-(3)top.w_data[255:0]
-[color] 3
-(4)top.w_data[255:0]
-[color] 3
-(5)top.w_data[255:0]
-[color] 3
-(6)top.w_data[255:0]
-[color] 3
-(7)top.w_data[255:0]
-[color] 3
-(8)top.w_data[255:0]
-[color] 3
-(9)top.w_data[255:0]
-[color] 3
-(10)top.w_data[255:0]
-[color] 3
-(11)top.w_data[255:0]
-[color] 3
-(12)top.w_data[255:0]
-[color] 3
-(13)top.w_data[255:0]
-[color] 3
-(14)top.w_data[255:0]
-[color] 3
-(15)top.w_data[255:0]
-[color] 3
-(16)top.w_data[255:0]
-[color] 3
-(17)top.w_data[255:0]
-[color] 3
-(18)top.w_data[255:0]
-[color] 3
-(19)top.w_data[255:0]
-[color] 3
-(20)top.w_data[255:0]
-[color] 3
-(21)top.w_data[255:0]
-[color] 3
-(22)top.w_data[255:0]
-[color] 3
-(23)top.w_data[255:0]
-[color] 3
-(24)top.w_data[255:0]
-[color] 3
-(25)top.w_data[255:0]
-[color] 3
-(26)top.w_data[255:0]
-[color] 3
-(27)top.w_data[255:0]
-[color] 3
-(28)top.w_data[255:0]
-[color] 3
-(29)top.w_data[255:0]
-[color] 3
-(30)top.w_data[255:0]
-[color] 3
-(31)top.w_data[255:0]
-[color] 3
-(32)top.w_data[255:0]
-[color] 3
-(33)top.w_data[255:0]
-[color] 3
-(34)top.w_data[255:0]
-[color] 3
-(35)top.w_data[255:0]
-[color] 3
-(36)top.w_data[255:0]
-[color] 3
-(37)top.w_data[255:0]
-[color] 3
-(38)top.w_data[255:0]
-[color] 3
-(39)top.w_data[255:0]
-[color] 3
-(40)top.w_data[255:0]
-[color] 3
-(41)top.w_data[255:0]
-[color] 3
-(42)top.w_data[255:0]
-[color] 3
-(43)top.w_data[255:0]
-[color] 3
-(44)top.w_data[255:0]
-[color] 3
-(45)top.w_data[255:0]
-[color] 3
-(46)top.w_data[255:0]
-[color] 3
-(47)top.w_data[255:0]
-[color] 3
-(48)top.w_data[255:0]
-[color] 3
-(49)top.w_data[255:0]
-[color] 3
-(50)top.w_data[255:0]
-[color] 3
-(51)top.w_data[255:0]
-[color] 3
-(52)top.w_data[255:0]
-[color] 3
-(53)top.w_data[255:0]
-[color] 3
-(54)top.w_data[255:0]
-[color] 3
-(55)top.w_data[255:0]
-[color] 3
-(56)top.w_data[255:0]
-[color] 3
-(57)top.w_data[255:0]
-[color] 3
-(58)top.w_data[255:0]
-[color] 3
-(59)top.w_data[255:0]
-[color] 3
-(60)top.w_data[255:0]
-[color] 3
-(61)top.w_data[255:0]
-[color] 3
-(62)top.w_data[255:0]
-[color] 3
-(63)top.w_data[255:0]
-[color] 3
-(64)top.w_data[255:0]
-[color] 3
-(65)top.w_data[255:0]
-[color] 3
-(66)top.w_data[255:0]
-[color] 3
-(67)top.w_data[255:0]
-[color] 3
-(68)top.w_data[255:0]
-[color] 3
-(69)top.w_data[255:0]
-[color] 3
-(70)top.w_data[255:0]
-[color] 3
-(71)top.w_data[255:0]
-[color] 3
-(72)top.w_data[255:0]
-[color] 3
-(73)top.w_data[255:0]
-[color] 3
-(74)top.w_data[255:0]
-[color] 3
-(75)top.w_data[255:0]
-[color] 3
-(76)top.w_data[255:0]
-[color] 3
-(77)top.w_data[255:0]
-[color] 3
-(78)top.w_data[255:0]
-[color] 3
-(79)top.w_data[255:0]
-[color] 3
-(80)top.w_data[255:0]
-[color] 3
-(81)top.w_data[255:0]
-[color] 3
-(82)top.w_data[255:0]
-[color] 3
-(83)top.w_data[255:0]
-[color] 3
-(84)top.w_data[255:0]
-[color] 3
-(85)top.w_data[255:0]
-[color] 3
-(86)top.w_data[255:0]
-[color] 3
-(87)top.w_data[255:0]
-[color] 3
-(88)top.w_data[255:0]
-[color] 3
-(89)top.w_data[255:0]
-[color] 3
-(90)top.w_data[255:0]
-[color] 3
-(91)top.w_data[255:0]
-[color] 3
-(92)top.w_data[255:0]
-[color] 3
-(93)top.w_data[255:0]
-[color] 3
-(94)top.w_data[255:0]
-[color] 3
-(95)top.w_data[255:0]
-[color] 3
-(96)top.w_data[255:0]
-[color] 3
-(97)top.w_data[255:0]
-[color] 3
-(98)top.w_data[255:0]
-[color] 3
-(99)top.w_data[255:0]
-[color] 3
-(100)top.w_data[255:0]
-[color] 3
-(101)top.w_data[255:0]
-[color] 3
-(102)top.w_data[255:0]
-[color] 3
-(103)top.w_data[255:0]
-[color] 3
-(104)top.w_data[255:0]
-[color] 3
-(105)top.w_data[255:0]
-[color] 3
-(106)top.w_data[255:0]
-[color] 3
-(107)top.w_data[255:0]
-[color] 3
-(108)top.w_data[255:0]
-[color] 3
-(109)top.w_data[255:0]
-[color] 3
-(110)top.w_data[255:0]
-[color] 3
-(111)top.w_data[255:0]
-[color] 3
-(112)top.w_data[255:0]
-[color] 3
-(113)top.w_data[255:0]
-[color] 3
-(114)top.w_data[255:0]
-[color] 3
-(115)top.w_data[255:0]
-[color] 3
-(116)top.w_data[255:0]
-[color] 3
-(117)top.w_data[255:0]
-[color] 3
-(118)top.w_data[255:0]
-[color] 3
-(119)top.w_data[255:0]
-[color] 3
-(120)top.w_data[255:0]
-[color] 3
-(121)top.w_data[255:0]
-[color] 3
-(122)top.w_data[255:0]
-[color] 3
-(123)top.w_data[255:0]
-[color] 3
-(124)top.w_data[255:0]
-[color] 3
-(125)top.w_data[255:0]
-[color] 3
-(126)top.w_data[255:0]
-[color] 3
-(127)top.w_data[255:0]
-[color] 3
-(128)top.w_data[255:0]
-[color] 3
-(129)top.w_data[255:0]
-[color] 3
-(130)top.w_data[255:0]
-[color] 3
-(131)top.w_data[255:0]
-[color] 3
-(132)top.w_data[255:0]
-[color] 3
-(133)top.w_data[255:0]
-[color] 3
-(134)top.w_data[255:0]
-[color] 3
-(135)top.w_data[255:0]
-[color] 3
-(136)top.w_data[255:0]
-[color] 3
-(137)top.w_data[255:0]
-[color] 3
-(138)top.w_data[255:0]
-[color] 3
-(139)top.w_data[255:0]
-[color] 3
-(140)top.w_data[255:0]
-[color] 3
-(141)top.w_data[255:0]
-[color] 3
-(142)top.w_data[255:0]
-[color] 3
-(143)top.w_data[255:0]
-[color] 3
-(144)top.w_data[255:0]
-[color] 3
-(145)top.w_data[255:0]
-[color] 3
-(146)top.w_data[255:0]
-[color] 3
-(147)top.w_data[255:0]
-[color] 3
-(148)top.w_data[255:0]
-[color] 3
-(149)top.w_data[255:0]
-[color] 3
-(150)top.w_data[255:0]
-[color] 3
-(151)top.w_data[255:0]
-[color] 3
-(152)top.w_data[255:0]
-[color] 3
-(153)top.w_data[255:0]
-[color] 3
-(154)top.w_data[255:0]
-[color] 3
-(155)top.w_data[255:0]
-[color] 3
-(156)top.w_data[255:0]
-[color] 3
-(157)top.w_data[255:0]
-[color] 3
-(158)top.w_data[255:0]
-[color] 3
-(159)top.w_data[255:0]
-[color] 3
-(160)top.w_data[255:0]
-[color] 3
-(161)top.w_data[255:0]
-[color] 3
-(162)top.w_data[255:0]
-[color] 3
-(163)top.w_data[255:0]
-[color] 3
-(164)top.w_data[255:0]
-[color] 3
-(165)top.w_data[255:0]
-[color] 3
-(166)top.w_data[255:0]
-[color] 3
-(167)top.w_data[255:0]
-[color] 3
-(168)top.w_data[255:0]
-[color] 3
-(169)top.w_data[255:0]
-[color] 3
-(170)top.w_data[255:0]
-[color] 3
-(171)top.w_data[255:0]
-[color] 3
-(172)top.w_data[255:0]
-[color] 3
-(173)top.w_data[255:0]
-[color] 3
-(174)top.w_data[255:0]
-[color] 3
-(175)top.w_data[255:0]
-[color] 3
-(176)top.w_data[255:0]
-[color] 3
-(177)top.w_data[255:0]
-[color] 3
-(178)top.w_data[255:0]
-[color] 3
-(179)top.w_data[255:0]
-[color] 3
-(180)top.w_data[255:0]
-[color] 3
-(181)top.w_data[255:0]
-[color] 3
-(182)top.w_data[255:0]
-[color] 3
-(183)top.w_data[255:0]
-[color] 3
-(184)top.w_data[255:0]
-[color] 3
-(185)top.w_data[255:0]
-[color] 3
-(186)top.w_data[255:0]
-[color] 3
-(187)top.w_data[255:0]
-[color] 3
-(188)top.w_data[255:0]
-[color] 3
-(189)top.w_data[255:0]
-[color] 3
-(190)top.w_data[255:0]
-[color] 3
-(191)top.w_data[255:0]
-[color] 3
-(192)top.w_data[255:0]
-[color] 3
-(193)top.w_data[255:0]
-[color] 3
-(194)top.w_data[255:0]
-[color] 3
-(195)top.w_data[255:0]
-[color] 3
-(196)top.w_data[255:0]
-[color] 3
-(197)top.w_data[255:0]
-[color] 3
-(198)top.w_data[255:0]
-[color] 3
-(199)top.w_data[255:0]
-[color] 3
-(200)top.w_data[255:0]
-[color] 3
-(201)top.w_data[255:0]
-[color] 3
-(202)top.w_data[255:0]
-[color] 3
-(203)top.w_data[255:0]
-[color] 3
-(204)top.w_data[255:0]
-[color] 3
-(205)top.w_data[255:0]
-[color] 3
-(206)top.w_data[255:0]
-[color] 3
-(207)top.w_data[255:0]
-[color] 3
-(208)top.w_data[255:0]
-[color] 3
-(209)top.w_data[255:0]
-[color] 3
-(210)top.w_data[255:0]
-[color] 3
-(211)top.w_data[255:0]
-[color] 3
-(212)top.w_data[255:0]
-[color] 3
-(213)top.w_data[255:0]
-[color] 3
-(214)top.w_data[255:0]
-[color] 3
-(215)top.w_data[255:0]
-[color] 3
-(216)top.w_data[255:0]
-[color] 3
-(217)top.w_data[255:0]
-[color] 3
-(218)top.w_data[255:0]
-[color] 3
-(219)top.w_data[255:0]
-[color] 3
-(220)top.w_data[255:0]
-[color] 3
-(221)top.w_data[255:0]
-[color] 3
-(222)top.w_data[255:0]
-[color] 3
-(223)top.w_data[255:0]
-[color] 3
-(224)top.w_data[255:0]
-[color] 3
-(225)top.w_data[255:0]
-[color] 3
-(226)top.w_data[255:0]
-[color] 3
-(227)top.w_data[255:0]
-[color] 3
-(228)top.w_data[255:0]
-[color] 3
-(229)top.w_data[255:0]
-[color] 3
-(230)top.w_data[255:0]
-[color] 3
-(231)top.w_data[255:0]
-[color] 3
-(232)top.w_data[255:0]
-[color] 3
-(233)top.w_data[255:0]
-[color] 3
-(234)top.w_data[255:0]
-[color] 3
-(235)top.w_data[255:0]
-[color] 3
-(236)top.w_data[255:0]
-[color] 3
-(237)top.w_data[255:0]
-[color] 3
-(238)top.w_data[255:0]
-[color] 3
-(239)top.w_data[255:0]
-[color] 3
-(240)top.w_data[255:0]
-[color] 3
-(241)top.w_data[255:0]
-[color] 3
-(242)top.w_data[255:0]
-[color] 3
-(243)top.w_data[255:0]
-[color] 3
-(244)top.w_data[255:0]
-[color] 3
-(245)top.w_data[255:0]
-[color] 3
-(246)top.w_data[255:0]
-[color] 3
-(247)top.w_data[255:0]
-[color] 3
-(248)top.w_data[255:0]
-[color] 3
-(249)top.w_data[255:0]
-[color] 3
-(250)top.w_data[255:0]
-[color] 3
-(251)top.w_data[255:0]
-[color] 3
-(252)top.w_data[255:0]
-[color] 3
-(253)top.w_data[255:0]
-[color] 3
-(254)top.w_data[255:0]
-[color] 3
-(255)top.w_data[255:0]
-@1401201
+bench.top.transmit_fifo.w_data[24:0]
+@800022
+bench.top.r_data[24:0]
+@28
+(0)bench.top.r_data[24:0]
+(1)bench.top.r_data[24:0]
+(2)bench.top.r_data[24:0]
+(3)bench.top.r_data[24:0]
+(4)bench.top.r_data[24:0]
+(5)bench.top.r_data[24:0]
+(6)bench.top.r_data[24:0]
+(7)bench.top.r_data[24:0]
+(8)bench.top.r_data[24:0]
+(9)bench.top.r_data[24:0]
+(10)bench.top.r_data[24:0]
+(11)bench.top.r_data[24:0]
+(12)bench.top.r_data[24:0]
+(13)bench.top.r_data[24:0]
+(14)bench.top.r_data[24:0]
+(15)bench.top.r_data[24:0]
+(16)bench.top.r_data[24:0]
+(17)bench.top.r_data[24:0]
+(18)bench.top.r_data[24:0]
+(19)bench.top.r_data[24:0]
+(20)bench.top.r_data[24:0]
+(21)bench.top.r_data[24:0]
+(22)bench.top.r_data[24:0]
+(23)bench.top.r_data[24:0]
+(24)bench.top.r_data[24:0]
+@1001200
 -group_end
 @28
-[color] 3
-top.adat_clk
-@200
--Output
-@22
-[color] 2
-top.transmit_counter[7:0]
+bench.top.nrzi_encoder.data_in
+bench.top.nrzi_encoder.nrzi_out
+@24
+bench.top.transmit_counter[4:0]
+@29
+bench.top.frame_bit0
 @28
-[color] 2
-top.nrzi_encoder.data_in
-[color] 2
-top.adat_out
-[color] 2
-top.underflow_out
+bench.top.frame_bit1
+bench.top.frame_bit2
+bench.top.frame_bit3
+bench.top.frame_bit4
+bench.top.frame_bit5
+bench.top.frame_bit6
+bench.top.frame_bit7
+bench.top.frame_bit8
+bench.top.frame_bit9
+bench.top.frame_bit10
+bench.top.frame_bit11
+bench.top.frame_bit12
+bench.top.frame_bit13
+bench.top.frame_bit14
+bench.top.frame_bit15
+bench.top.frame_bit16
+bench.top.frame_bit17
+bench.top.frame_bit18
+bench.top.frame_bit19
+bench.top.frame_bit20
+bench.top.frame_bit21
+bench.top.frame_bit22
+bench.top.frame_bit23
+bench.top.frame_bit24
+bench.top.frame_bit25
+bench.top.frame_bit26
+bench.top.frame_bit27
+bench.top.frame_bit28
+bench.top.frame_bit29
 [pattern_trace] 1
 [pattern_trace] 0


### PR DESCRIPTION
Rewritten the transmitter to use a narrower fifo.
This saves some LUTs (~8000 for 4 transmitters in adat-usb2-audio-interface).

Changes in behavior compared to the previous version:
   * fifo_level_out --> the levels reported will be higher, since the
     fifo width was reduced
   * the addr_in input is not used anymore. Instead the caller needs to ensure
     that the data is submitted in channel order.
   * The sync_pad + user_bits is transmitted at the end of each adat frame
   * The test-bench uses 50MHz sync clock now, to reflect the currently
     used FPGA clock