### PR TITLE
Minor transmitter optimizations

### DIFF
--- a/adat/transmitter.py
+++ b/adat/transmitter.py
@@ -87,15 +87,14 @@ class ADATTransmitter(Elaboratable):
         # needed for output processing
         m.submodules.nrzi_encoder = nrzi_encoder = NRZIEncoder()
 
-        transmitted_frame_bits = Array([Signal(name=f"frame_bit{b}") for b in range(30)])
-        transmitted_frame      = Cat(transmitted_frame_bits)
+        transmitted_frame      = Signal(30)
         transmit_counter       = Signal(5)
 
         comb += [
             self.ready_out       .eq(transmit_fifo.w_rdy),
             self.fifo_level_out  .eq(transmit_fifo.w_level),
             self.adat_out        .eq(nrzi_encoder.nrzi_out),
-            nrzi_encoder.data_in .eq(transmitted_frame_bits[transmit_counter]),
+            nrzi_encoder.data_in .eq(transmitted_frame.bit_select(transmit_counter, 1)),
             self.underflow_out   .eq(0)
         ]
 

--- a/adat/transmitter.py
+++ b/adat/transmitter.py
@@ -117,12 +117,12 @@ class ADATTransmitter(Elaboratable):
 
         with m.FSM():
             with m.State("DATA"):
-                with m.If(transmit_fifo.w_rdy):
+                with m.If(self.ready_out):
                     with m.If(self.valid_in):
                         sync += [
                             samples_write_port.data.eq(self.sample_in),
                             samples_write_port.addr.eq(self.addr_in),
-                            samples_write_port.en.eq(1),
+                            samples_write_port.en.eq(1)
                         ]
 
                         with m.If(self.last_in):


### PR DESCRIPTION
We can fill the samples_write_port even if the fifo is w_rdy==0
We only need to ensure the fifo is ready when calling write_frame_border()