### PR TITLE
Fixed testbench for nrzidecoder and added assertions

### DIFF
--- a/tests/nrzi-decoder-bench-48000.gtkw
+++ b/tests/nrzi-decoder-bench-48000.gtkw
@@ -1,61 +1,45 @@
 [*]
-[*] GTKWave Analyzer v3.3.108 (w)1999-2020 BSI
-[*] Fri Apr  9 22:04:26 2021
+[*] GTKWave Analyzer v3.3.106 (w)1999-2020 BSI
+[*] Fri Jan 21 17:31:27 2022
 [*]
-[dumpfile] "nrzi-decoder-bench-48000.vcd"
-[dumpfile_mtime] "Fri Apr  9 22:01:59 2021"
-[dumpfile_size] 1469939
-[savefile] "nrzi-decoder-bench-48000.gtkw"
-[timestart] 69460000
-[size] 3822 2022
+[dumpfile] "./nrzi-decoder-bench-48000.vcd"
+[dumpfile_mtime] "Fri Jan 21 17:31:12 2022"
+[dumpfile_size] 1966637
+[savefile] "./nrzi-decoder-bench-48000.gtkw"
+[timestart] 0
+[size] 1850 1011
 [pos] -1 -1
-*-19.631739 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
-[treeopen] top.
+*-25.631739 48195000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] bench.
+[treeopen] bench.top.
+[treeopen] bench.top.nrzidecoder.
 [sst_width] 453
 [signals_width] 435
 [sst_expanded] 1
 [sst_vpaned_height] 622
 @28
-top.clk
-top.fsm_state
-[color] 3
-top.invalid_frame_in
-[color] 3
-top.nrzi
-[color] 2
-top.nrzi_prev
+bench.top.clk
+bench.top.adat_clk
+bench.top.nrzidecoder.invalid_frame_in
+bench.top.nrzi_in
+bench.top.nrzidecoder.nrzi
+bench.top.nrzidecoder.data_out
 @29
-[color] 3
-top.recovered_clock_out
+bench.top.nrzidecoder.data_out_en
 @28
-top.sync_counter.active_in
-top.got_edge
-@8022
-top.bit_counter[6:0]
-top.dead_counter[7:0]
-@8024
-top.sync_counter.counter_out[6:0]
-@20000
--
-@8024
-top.sync_counter.divided_counter_out[6:0]
+bench.top.nrzidecoder.recovered_clock_out
+@24
+bench.top.nrzidecoder.bit_counter[6:0]
+bench.top.nrzidecoder.counter_out[6:0]
+bench.top.nrzidecoder.dead_counter[7:0]
+@22
+bench.top.nrzidecoder.divided_counter_out[6:0]
 @28
-top.sync_counter.active_in
-[color] 3
-top.sync_counter.reset_in
-top.sync_counter.rst
-top.nrzi_prev
-[color] 3
-top.data_out_en
-[color] 2
-top.data_out
-[color] 2
-top.running
-@20000
--
-@8022
-top.dead_counter[7:0]
-@20000
--
+bench.top.nrzidecoder.fsm_state
+bench.top.nrzidecoder.got_edge
+bench.top.nrzidecoder.nrzi_prev
+bench.top.nrzidecoder.output
+bench.top.nrzidecoder.reset_in
+bench.top.nrzidecoder.running
 [pattern_trace] 1
 [pattern_trace] 0

--- a/tests/nrzidecoder-bench.py
+++ b/tests/nrzidecoder-bench.py
@@ -3,11 +3,37 @@ import sys
 from amaranth.hdl.cd import ClockDomain
 sys.path.append('.')
 from amaranth.sim import Simulator, Tick
+from amaranth import Elaboratable, Signal, Module
 
 from adat.nrzidecoder import NRZIDecoder
 from testdata    import one_empty_adat_frame, \
                         sixteen_frames_with_channel_num_msb_and_sample_num, \
-                        encode_nrzi
+                        encode_nrzi, validate_output
+
+# This class simplifies testing since the nrzidecoder does not use the adat
+# domain. Therefore we simulate the input from the adat domain with this wrapper class.
+class NRZIDecoderTester(Elaboratable):
+    def __init__(self, clk_freq: int):
+        self.nrzi_in = Signal()
+        self.invalid_frame_in = Signal()
+        self.data_out = Signal()
+        self.data_out_en = Signal()
+        self.recovered_clock_out = Signal()
+        self.clk_freq = clk_freq
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+        m.submodules.nrzidecoder = nrzidecoder = NRZIDecoder(self.clk_freq)
+        m.d.adat += [
+            nrzidecoder.nrzi_in.eq(self.nrzi_in),
+            nrzidecoder.invalid_frame_in.eq(self.invalid_frame_in)
+        ]
+        m.d.sync += [
+            self.data_out.eq(nrzidecoder.data_out),
+            self.data_out_en.eq(nrzidecoder.data_out_en),
+            self.recovered_clock_out.eq(nrzidecoder.recovered_clock_out)
+        ]
+        return m
 
 def test_with_samplerate(samplerate: int=48000):
     """run adat signal simulation with the given samplerate"""
@@ -15,32 +41,32 @@ def test_with_samplerate(samplerate: int=48000):
     # then 1 separator, 10 sync bits (zero), 1 separator and 4 user bits
 
     clk_freq = 100e6
-    dut = NRZIDecoder(clk_freq)
-    adat_freq = dut.adat_freq(samplerate)
+    dut = NRZIDecoderTester(clk_freq)
+    adat_freq = NRZIDecoder.adat_freq(samplerate)
     clockratio = clk_freq / adat_freq
+
 
     sim = Simulator(dut)
     sim.add_clock(1.0/clk_freq, domain="sync")
     sim.add_clock(1.0/adat_freq, domain="adat")
 
-    sixteen_adat_frames = sixteen_frames_with_channel_num_msb_and_sample_num()
-    testdata = encode_nrzi(
-        one_empty_adat_frame() +
-        sixteen_adat_frames[0:256] +
-        [0] * 64 +
-        sixteen_adat_frames[256:]
-    )
-
     print(f"FPGA clock freq: {clk_freq}")
     print(f"ADAT clock freq: {adat_freq}")
     print(f"FPGA/ADAT freq: {clockratio}")
 
-    no_cycles = 10
+    sixteen_adat_frames = sixteen_frames_with_channel_num_msb_and_sample_num()
+    interrupted_adat_stream = [0] * 64
 
-    def sync_process():
-        for _ in range(int(clockratio) * no_cycles):
-            yield Tick("sync")
+    plain_testdata = one_empty_adat_frame() + \
+        sixteen_adat_frames[0:256] + \
+        interrupted_adat_stream + \
+        sixteen_adat_frames[256:]
 
+    testdata = encode_nrzi(plain_testdata)
+
+    no_cycles = len(testdata)
+
+    # Send the adat stream
     def adat_process():
         bitcount :int = 0
         for bit in testdata: #[224:512 * 2]:
@@ -57,10 +83,63 @@ def test_with_samplerate(samplerate: int=48000):
             yield Tick("adat")
             bitcount += 1
 
+    # Process the adat stream and validate output
+    def sync_process():
+        # Obtain the output data
+        out_data = []
+        for _ in range(int(clockratio) * no_cycles):
+            yield Tick("sync")
+            if (yield dut.data_out_en == 1):
+                bit = yield dut.data_out
+                yield out_data.append(bit)
+
+        #
+        # Validate output
+        #
+
+        # omit a 1 at the end of the sync pad
+        out_data = out_data[1:]
+
+        # Whenever the state machine switches from SYNC to DECODE we need to omit the first 11 sync bits
+        validate_output(out_data[:256 - 12], one_empty_adat_frame()[12:256])
+        out_data = out_data[256-12:]
+
+        validate_output(out_data[:256], sixteen_adat_frames[:256])
+        out_data = out_data[256:]
+
+        # now the adat stream was interrupted, it continues to output zeroes, until it enters the SYNC state
+        validate_output(out_data[:10], interrupted_adat_stream[:10])
+        out_data = out_data[10:]
+
+        # followed by 2 well formed adat frames
+
+        # omit the first 11 sync bits
+        validate_output(out_data[:256 - 12], sixteen_adat_frames[256 + 12:2 * 256])
+        out_data = out_data[256 - 12:]
+
+        validate_output(out_data[:256], sixteen_adat_frames[2 * 256:3 * 256])
+        out_data = out_data[256:]
+
+        # followed by one invalid frame - the state machine SYNCs again
+
+        # followed by 13 well-formed frames
+
+        # omit the first 11 sync bits
+        validate_output(out_data[:256 - 12], sixteen_adat_frames[3 * 256 + 12:4 * 256])
+        out_data = out_data[256-12:]
+
+        for i in range(4, 16):
+            validate_output(out_data[:256], sixteen_adat_frames[i * 256:(i + 1) * 256])
+            out_data = out_data[256:]
+
+        print("Success!")
+
+
     sim.add_sync_process(sync_process, domain="sync")
     sim.add_sync_process(adat_process, domain="adat")
     with sim.write_vcd(f'nrzi-decoder-bench-{str(samplerate)}.vcd'):
         sim.run()
+
 
 if __name__ == "__main__":
     test_with_samplerate(48000)

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -99,11 +99,19 @@ def bits_to_int(bitlist):
 def print_frame(frame):
     return ", ".join("0x{}".format(num) for num in frame)
 
-def print_assert_failure(frame):
-    return "Result was: {}".format(print_frame(frame))
+
+def print_assert_failure(receivedFrame, expectedFrame = None):
+    if expectedFrame is not None:
+        return "Expected:\n{}\nResult was:\n{}".format(print_frame(expectedFrame), print_frame(receivedFrame))
+    else:
+        return "Result was: {}".format(print_frame(receivedFrame))
 
 def print_assert_failure_context(signal):
     return "Next 256 signal bits are: {}".format(signal[:256])
+
+def validate_output(receivedFrame, expectedFrame):
+    assert receivedFrame == expectedFrame, print_assert_failure(receivedFrame, expectedFrame)
+
 
 def adat_decode(signal):
     """decode adat frames, after NRZI-decoding"""


### PR DESCRIPTION
Hi Hans,

I tried to fix the failing tests for the nrzidecoder and the receiver.
Here is my proposal for the nrzidecoder. Wanted to give you a chance to check it, to see whether it is ok to take the same approach for the receiver test.

Especially interested if you know an easier way to simulate input in the adat clock rate without having an actual adat domain within the tested module (nrzidecoder). I used a wrapper class now: https://github.com/amaranth-community-unofficial/adat-core/compare/master...fritzbauer:fixReceiverTest?expand=1#diff-7a191819770577590d907a01e14e7df59cd82b1453613466c0df29c4e6aef456R15

Thanks,
Rouven